### PR TITLE
Add withTransaction'

### DIFF
--- a/snaplet-hdbc.cabal
+++ b/snaplet-hdbc.cabal
@@ -30,6 +30,7 @@ Library
     data-lens-template        >= 2.1 && < 2.2,
     HDBC                      >= 2.2,
     mtl                       >  2.0   && < 2.1,
+    MonadCatchIO-mtl          >= 0.3 && < 0.4,
     snap                      >= 0.6   && < 0.7,
     text                      >= 0.11,
     unordered-containers      >= 0.1.4


### PR DESCRIPTION
`withTransaction'` is like `withTransaction` however it does not require
the action to be in the IO monad, but a monad which is an instance of
the HasHdbc/MonadCatchIO typeclasses.
